### PR TITLE
Convert queue datafactory back to using the "game" type

### DIFF
--- a/Plugins/RallyHereStart/Source/RallyHereStart/Private/DataFactories/RHQueueDataFactory.cpp
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Private/DataFactories/RHQueueDataFactory.cpp
@@ -9,7 +9,7 @@
 URHQueueDataFactory::URHQueueDataFactory(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer),
 	bInitialized(false),
-	RHSessionType(FString(TEXT("browser_game"))),
+	RHSessionType(FString(TEXT("game"))),
 	SessionLeaderNameFieldName(FString(TEXT("leader_name"))),
 	CustomMatchMembers(),
 	SelectedCustomMatchMapRowName(FName(TEXT("Map1"))),
@@ -529,6 +529,13 @@ void URHQueueDataFactory::HandleCustomMatchSessionCreated(bool bSuccess, URH_Joi
 	if (bSuccess)
 	{
 		CustomMatchSession = JoinedSession;
+
+		// mark the custom session as publicly joinable
+		{
+			auto UpdateRequest = CustomMatchSession->GetSessionUpdateInfoDefaults();
+			UpdateRequest.SetJoinable(true);
+			CustomMatchSession->UpdateSessionInfo(UpdateRequest);
+		}
 
 		// Set leader's name in session custom data
 		UpdateCustomSessionBrowserInfo();


### PR DESCRIPTION
Make custom games change their joinability to Joinable on creation, rather than relying on "browser_game" type to do it.