### PR TITLE
Swap from specific platform checks to rely on PLATFORM_DESKTOP

### DIFF
--- a/Plugins/RallyHereStart/Source/RallyHereStart/Private/GameFramework/RHGameUserSettings.cpp
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Private/GameFramework/RHGameUserSettings.cpp
@@ -1152,7 +1152,7 @@ EGamepadIcons URHGameUserSettings::GetGamepadIconSet() const
 {
 	const FString PlatformName = UGameplayStatics::GetPlatformName();
 
-	if (PlatformName == TEXT("Windows") || PlatformName == TEXT("Mac") || PlatformName == TEXT("Linux"))
+	if (PLATFORM_DESKTOP)
 	{
 		return GamepadIconSet;
 	}

--- a/Plugins/RallyHereStart/Source/RallyHereStart/Private/Managers/RHJsonDataFactory.cpp
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Private/Managers/RHJsonDataFactory.cpp
@@ -432,10 +432,10 @@ void URHJsonDataFactory::CheckShouldShowForPlayer(URHJsonData* JsonData, URH_Pla
 		}
 
 		const FString PlatformName = UGameplayStatics::GetPlatformName();
-		const bool isPc = PlatformName == TEXT("Windows") || PlatformName == TEXT("Mac") || PlatformName == TEXT("Linux");
+		const bool isPc = PLATFORM_DESKTOP;
 		const bool isPS4 = PlatformName == TEXT("PS4");
 		const bool isPS5 = PlatformName == TEXT("PS5");
-		const bool isXB1 = PlatformName == TEXT("XboxOne");
+		const bool isXB1 = PlatformName == TEXT("XboxOne") || TEXT("XB1");
 		const bool isXSX = PlatformName == TEXT("XSX");
 		const bool isSwitch = PlatformName == TEXT("Switch");
 		const bool isIOS = PlatformName == TEXT("IOS");

--- a/Plugins/RallyHereStart/Source/RallyHereStart/Private/RHUIBlueprintFunctionLibrary.cpp
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Private/RHUIBlueprintFunctionLibrary.cpp
@@ -81,7 +81,7 @@ bool URHUIBlueprintFunctionLibrary::IsPlatformType(bool IsConsole, bool IsPC, bo
 	{
 		return IsMobile;
 	}
-	else if (PlatformName == TEXT("Windows") || PlatformName == TEXT("Mac") || PlatformName == TEXT("Linux"))
+	else if (PLATFORM_DESKTOP)
 	{
 		return IsPC;
 	}

--- a/Plugins/RallyHereStart/Source/RallyHereStart/Private/Shared/Settings/RHSettingsMenu.cpp
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Private/Shared/Settings/RHSettingsMenu.cpp
@@ -68,7 +68,7 @@ void URHSettingsMenu::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
 				SettingsState.bIsMouseAttached = false;
 				SettingsState.bIsTouchMode = false;
 			}
-			else if (PlatformName == TEXT("Windows") || PlatformName == TEXT("Mac") || PlatformName == TEXT("Linux"))
+			else if (PLATFORM_DESKTOP)
 			{
 				SettingsState.bIsGamepadAttached = GenericApplication->IsGamepadAttached();
 				SettingsState.bIsMouseAttached = true;

--- a/Plugins/RallyHereStart/Source/RallyHereStart/Public/DataFactories/RHSettingsDataFactory.h
+++ b/Plugins/RallyHereStart/Source/RallyHereStart/Public/DataFactories/RHSettingsDataFactory.h
@@ -113,12 +113,14 @@ public:
 	bool IsPlatformAllowed(const FString& PlatformName) const
 	{
 		if (PlatformName == TEXT("XboxOne")) return XBoxOne;
+		if (PlatformName == TEXT("XB1")) return XBoxOne;
 		if (PlatformName == TEXT("XSX")) return XSX;
 		if (PlatformName == TEXT("PS4")) return PS4;
 		if (PlatformName == TEXT("PS5")) return PS5;
 		if (PlatformName == TEXT("Linux")) return Linux;
 		if (PlatformName == TEXT("Mac")) return Mac;
 		if (PlatformName == TEXT("Windows")) return Windows;
+		if (PlatformName == TEXT("WinGDK")) return Windows;
 		if (PlatformName == TEXT("Switch")) return Switch;
 		if (PlatformName == TEXT("IOS")) return IOS;
 		if (PlatformName == TEXT("Android")) return Android;

--- a/RHExampleGame.uproject
+++ b/RHExampleGame.uproject
@@ -73,6 +73,7 @@
 		"Desktop",
 		"LinuxNoEditor",
 		"WindowsNoEditor",
+		"WinGDK",
 		"XboxOne",
 		"PS4"
 	]


### PR DESCRIPTION
Add in a couple cases where platform names are explicity handled to understand XB1 and WinGDK variants